### PR TITLE
[issue/1] Abillity to specify output path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+*.iml
+node_modules

--- a/index.js
+++ b/index.js
@@ -3,6 +3,37 @@
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 const fs = require('fs');
+const program = require('commander');
+
+program
+  .version('1.0.3')
+  .usage('[options] [path]')
+  .option('-o, --output <path>', 'Path mix should be setup in')
+  .parse(process.argv);
+
+
+let pathToUse = "";
+
+if(program.output || program.args.length > 0) {
+  if(program.output) {
+    pathToUse = program.output;
+  } else {
+    pathToUse = program.args[0];
+  }
+
+  if(!fs.existsSync(pathToUse)) {
+    console.log("Error: " + pathToUse + " does not exist.");
+    process.exit(1);
+  }
+
+  let stat = fs.statSync(pathToUse);
+  if(!stat.isDirectory()) {
+    console.log("Error: " + pathToUse + " is not a directory.");
+    process.exit(1);
+  }
+
+  process.chdir(pathToUse);
+}
 
 const currentDir = process.cwd();
 const packagePath = `${currentDir}/package.json`;

--- a/index.js
+++ b/index.js
@@ -4,9 +4,10 @@ const util = require('util');
 const exec = util.promisify(require('child_process').exec);
 const fs = require('fs');
 const program = require('commander');
+const pkgjson = require("./package");
 
 program
-  .version('1.0.3')
+  .version(pkgjson.version)
   .usage('[options] [path]')
   .option('-o, --output <path>', 'Path mix should be setup in')
   .parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mix-setup",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Simple utility to setup laravel-mix",
   "main": "index.js",
   "preferGlobal": true,
@@ -10,5 +10,8 @@
   },
   "repository": "https://github.com/ranbogmord/mix-setup.git",
   "author": "John Eriksson <root@ranbogmord.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "commander": "^2.12.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mix-setup",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Simple utility to setup laravel-mix",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
Using the `-o` flag or just specifying a path, you can now have mix setup in a different directory. Also checks if the path exists and is a directory.

Might wanna check for write permissions to the given path.
 
In reference to #1 